### PR TITLE
Refactor remove zerto vpg

### DIFF
--- a/ZertoApiWrapper/Public/Remove-ZertoVpg.ps1
+++ b/ZertoApiWrapper/Public/Remove-ZertoVpg.ps1
@@ -1,37 +1,72 @@
 <# .ExternalHelp ./en-us/ZertoApiWrapper-help.xml #>
 function Remove-ZertoVpg {
-    [cmdletbinding( SupportsShouldProcess = $true )]
+    [cmdletbinding( SupportsShouldProcess = $true, DefaultParameterSetName = "vpgIdentifier" )]
     param(
         [Parameter(
             Mandatory = $true,
-            HelpMessage = "Name of the VPG to delete."
+            ParameterSetName = "vpgName",
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = "Name(s) of the VPG(s) to delete."
         )]
-        [string]$vpgName,
+        [string[]]$vpgName,
+        [Parameter(
+            Mandatory = $true,
+            ParameterSetName = "vpgIdentifier",
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = "vpgIdentifier(s) of the VPG(s) to delete."
+        )]
+        [string[]]$vpgidentifier,
         [Parameter(
             HelpMessage = "Use this parameter to keep the recovery volumes at the target site, by setting it to True.  If the virtual machines in the deleted VPG are reprotected, these volumes can be used as preseeded volumes to speed up the initial synchronization of the new VPG. Default is to remove Recovery Volumes"
         )]
-        [bool]$keepRecoveryVolumes = $false,
+        [switch]$keepRecoveryVolumes = $false,
         [Parameter(
             HelpMessage = "Use this parameter to force delete the VPG, by setting this parameter equal to true."
         )]
-        [bool]$force = $false
+        [switch]$force = $false
     )
 
     begin {
         $baseUri = "vpgs"
-        $vpgIdentifier = $(get-zertovpg -name $vpgName).vpgIdentifier
+        $body = @{}
+        if ($keepRecoveryVolumes) {
+            $body['KeepRecoveryVolumes'] = $True
+        } else {
+            $body['KeepRecoveryVolumes'] = $False
+        }
+        if ($force) {
+            $body['force'] = $True
+        } else {
+            $body['force'] = $False
+        }
     }
 
     process {
-        $vpgIdentifier = $(get-zertovpg -name $vpgName).vpgIdentifier
-        if ( $vpgIdentifier ) {
-            $uri = "{0}/{1}" -f $baseUri, $vpgIdentifier
-            $body = @{"Force" = $force; "KeepRecoveryVolumes" = $keepRecoveryVolumes}
-            if ($PSCmdlet.ShouldProcess( $vpgName + " and these settings: " + $($body | ConvertTo-Json) ) ) {
-                Invoke-ZertoRestRequest -uri $uri -body $($body | ConvertTo-Json) -Method "DELETE"
+        switch ($PSCmdlet.ParameterSetName) {
+            "vpgName" {
+                foreach ($name in $vpgName) {
+                    $id = $(get-zertovpg -name $name).vpgIdentifier
+                    if ($id) {
+                        $uri = "{0}/{1}" -f $baseUri, $id
+                        if ($PSCmdlet.ShouldProcess( $name + " and these settings: " + $($body | ConvertTo-Json) ) ) {
+                            Invoke-ZertoRestRequest -uri $uri -body $($body | ConvertTo-Json) -Method "DELETE"
+                        }
+                    } else {
+                        Write-Output "VPG with name $vpgName not found. Please check the name and try again"
+                    }
+                }
             }
-        } else {
-            Write-Output "VPG with name $vpgName not found. Please check the name and try again"
+
+            "vpgIdentifier" {
+                foreach ($id in $vpgIdentifier) {
+                    $uri = "{0}/{1}" -f $baseUri, $id
+                    if ($PSCmdlet.ShouldProcess( $id + " and these settings: " + $($body | ConvertTo-Json) ) ) {
+                        Invoke-ZertoRestRequest -uri $uri -body $($body | ConvertTo-Json) -Method "DELETE"
+                    }
+                }
+            }
         }
     }
 

--- a/ZertoApiWrapper/Public/en-us/ZertoApiWrapper-help.xml
+++ b/ZertoApiWrapper/Public/en-us/ZertoApiWrapper-help.xml
@@ -5015,7 +5015,7 @@
           <maml:name>System.Object</maml:name>
         </dev:type>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>JSON data returned from the API as a PowerShell object containing settings for the selected VPG(s).</maml:para>
         </maml:description>
       </command:returnValue>
     </command:returnValues>
@@ -5033,7 +5033,7 @@
         </dev:remarks>
       </command:example>
       <command:example>
-        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <maml:title>-------------------------- Example 2 --------------------------</maml:title>
         <dev:code>PS C:\&gt; Get-ZertoVpg -name "MyVpg"</dev:code>
         <dev:remarks>
           <maml:para>Returns information about VPG with the name "MyVpg"</maml:para>
@@ -9664,26 +9664,13 @@
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Remove-ZertoVpg</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
-          <maml:name>vpgName</maml:name>
-          <maml:Description>
-            <maml:para>Name of the VPG to delete.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>force</maml:name>
           <maml:Description>
-            <maml:para>Use this parameter to force delete the VPG, by setting this parameter equal to true.</maml:para>
+            <maml:para>Use this switch to force delete the VPG. If unused, a non-forced remove vpg operation will be executed.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
           <dev:type>
-            <maml:name>Boolean</maml:name>
+            <maml:name>SwitchParameter</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
@@ -9691,11 +9678,81 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>keepRecoveryVolumes</maml:name>
           <maml:Description>
-            <maml:para>Use this parameter to keep the recovery volumes at the target site, by setting it to True.  If the virtual machines in the deleted VPG are re-protected, these volumes can be used as pre-seed volumes to speed up the initial synchronization of the new VPG. Default is to remove Recovery Volumes</maml:para>
+            <maml:para>Use this switch to keep the recovery volumes at the target site.  If the virtual machines in the deleted VPG are re-protected, these volumes can be used as pre-seed volumes to speed up the initial synchronization of the new VPG. If this switch is not set, recovery volumes will not be retained. If required to be retained, get the path to these volumes prior to the deletion to use as pre-seed volumes for an easier operation.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
           <dev:type>
-            <maml:name>Boolean</maml:name>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>vpgidentifier</maml:name>
+          <maml:Description>
+            <maml:para>vpgIdentifier(s) of the VPG(s) to delete.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:Description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:Description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Remove-ZertoVpg</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+          <maml:name>vpgName</maml:name>
+          <maml:Description>
+            <maml:para>Name(s) of the VPG(s) to delete.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>force</maml:name>
+          <maml:Description>
+            <maml:para>Use this switch to force delete the VPG. If unused, a non-forced remove vpg operation will be executed.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>keepRecoveryVolumes</maml:name>
+          <maml:Description>
+            <maml:para>Use this switch to keep the recovery volumes at the target site.  If the virtual machines in the deleted VPG are re-protected, these volumes can be used as pre-seed volumes to speed up the initial synchronization of the new VPG. If this switch is not set, recovery volumes will not be retained. If required to be retained, get the path to these volumes prior to the deletion to use as pre-seed volumes for an easier operation.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
@@ -9728,11 +9785,11 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>force</maml:name>
         <maml:Description>
-          <maml:para>Use this parameter to force delete the VPG, by setting this parameter equal to true.</maml:para>
+          <maml:para>Use this switch to force delete the VPG. If unused, a non-forced remove vpg operation will be executed.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
-          <maml:name>Boolean</maml:name>
+          <maml:name>SwitchParameter</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
@@ -9740,23 +9797,35 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>keepRecoveryVolumes</maml:name>
         <maml:Description>
-          <maml:para>Use this parameter to keep the recovery volumes at the target site, by setting it to True.  If the virtual machines in the deleted VPG are re-protected, these volumes can be used as pre-seed volumes to speed up the initial synchronization of the new VPG. Default is to remove Recovery Volumes</maml:para>
+          <maml:para>Use this switch to keep the recovery volumes at the target site.  If the virtual machines in the deleted VPG are re-protected, these volumes can be used as pre-seed volumes to speed up the initial synchronization of the new VPG. If this switch is not set, recovery volumes will not be retained. If required to be retained, get the path to these volumes prior to the deletion to use as pre-seed volumes for an easier operation.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
-          <maml:name>Boolean</maml:name>
+          <maml:name>SwitchParameter</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <maml:name>vpgidentifier</maml:name>
+        <maml:Description>
+          <maml:para>vpgIdentifier(s) of the VPG(s) to delete.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
         <maml:name>vpgName</maml:name>
         <maml:Description>
-          <maml:para>Name of the VPG to delete.</maml:para>
+          <maml:para>Name(s) of the VPG(s) to delete.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
         <dev:type>
-          <maml:name>String</maml:name>
+          <maml:name>String[]</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -9802,7 +9871,7 @@
           <maml:name>System.Object</maml:name>
         </dev:type>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Task Identifier of the Remove operation</maml:para>
         </maml:description>
       </command:returnValue>
     </command:returnValues>
@@ -9821,9 +9890,23 @@
       </command:example>
       <command:example>
         <maml:title>-------------------------- Example 2 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; Remove-ZertoVpg -vpgName "MyVpg" -keepRecoveryVolumes</dev:code>
+        <dev:code>PS C:\&gt; Remove-ZertoVpg -vpgName "MyVpg", "MyOtherVpg" -keepRecoveryVolumes</dev:code>
         <dev:remarks>
-          <maml:para>Deletes Zerto Virtual Protection Group named "MyVpg". Recovery volumes at the recovery site will be retained.</maml:para>
+          <maml:para>Deletes Zerto Virtual Protection Groups named "MyVpg" and "MyOtherVpg." Recovery volumes at the recovery site will be retained for both VPGs.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 3 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Remove-ZertoVpg -vpgIdentifier "MyVpgIdentifier" -keepRecoveryVolumes</dev:code>
+        <dev:remarks>
+          <maml:para>Deletes Zerto Virtual Protection Group with vpgIdentifier "MyVpgIdentifier". Recovery volumes at the recovery site will be retained.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 4 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-ZertoVpg -recoverySiteIdentifier "MyRecoverySiteIdentifier" | Remove-ZertoVpg</dev:code>
+        <dev:remarks>
+          <maml:para>Uses the `Get-ZertoVpg` function to get all VPGs currently being protected to recovery site with identifier "MyRecoverySiteIdentifier." This information is piped into the `Remove-ZertoVpg` function and will remove all VPGs being protected to the specified recovery site.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/docs/Add-ZertoPeerSite.md
+++ b/docs/Add-ZertoPeerSite.md
@@ -93,8 +93,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -105,4 +104,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Peer Site End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/index.html#page/RestfulAPIs%2FStatusAPIs.5.044.html%23)

--- a/docs/Checkpoint-ZertoVpg.md
+++ b/docs/Checkpoint-ZertoVpg.md
@@ -61,8 +61,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -73,4 +72,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Connect-ZertoServer.md
+++ b/docs/Connect-ZertoServer.md
@@ -93,8 +93,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -105,6 +104,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Session End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/index.html#page/RestfulAPIs%2FStatusAPIs.5.068.html%23)
 [PSCredential Documentation](https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.pscredential?view=pscore-6.0.0)
 [Get-Credential Documentation](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/get-credential?view=powershell-6)

--- a/docs/Disconnect-ZertoServer.md
+++ b/docs/Disconnect-ZertoServer.md
@@ -13,7 +13,7 @@ Disconnects the current session from the ZVM
 ## SYNTAX
 
 ```
-Disconnect-ZertoServer
+Disconnect-ZertoServer [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,6 +30,9 @@ Disconnects from the Zerto Server
 
 ## PARAMETERS
 
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
 ## INPUTS
 
 ### None
@@ -39,4 +42,5 @@ Disconnects from the Zerto Server
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Session End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/index.html#page/RestfulAPIs%2FStatusAPIs.5.068.html%23)

--- a/docs/Edit-ZertoVra.md
+++ b/docs/Edit-ZertoVra.md
@@ -166,8 +166,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -178,4 +177,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VRA End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.117.html#)

--- a/docs/Get-ZertoAlert.md
+++ b/docs/Get-ZertoAlert.md
@@ -295,8 +295,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -307,4 +306,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Alerts End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/index.html#page/RestfulAPIs%2FStatusAPIs.5.009.html%23)

--- a/docs/Get-ZertoDatastore.md
+++ b/docs/Get-ZertoDatastore.md
@@ -59,8 +59,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -71,4 +70,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Datastore Information End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.016.html#)

--- a/docs/Get-ZertoEvent.md
+++ b/docs/Get-ZertoEvent.md
@@ -344,8 +344,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -356,4 +355,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Events End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.022.html#)

--- a/docs/Get-ZertoLicense.md
+++ b/docs/Get-ZertoLicense.md
@@ -13,7 +13,7 @@ Retrieve information about a Zerto Virtual Replication license.
 ## SYNTAX
 
 ```
-Get-ZertoLicense
+Get-ZertoLicense [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,6 +30,9 @@ Retrieve information about a Zerto Virtual Replication license.
 
 ## PARAMETERS
 
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
 ## INPUTS
 
 ### None
@@ -39,4 +42,5 @@ Retrieve information about a Zerto Virtual Replication license.
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API License Information](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.034.html#)

--- a/docs/Get-ZertoLocalSite.md
+++ b/docs/Get-ZertoLocalSite.md
@@ -46,8 +46,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -58,4 +57,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Local Site End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.038.html#)

--- a/docs/Get-ZertoPeerSite.md
+++ b/docs/Get-ZertoPeerSite.md
@@ -162,8 +162,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -174,4 +173,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Peer Site End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.038.html#)

--- a/docs/Get-ZertoProtectedVm.md
+++ b/docs/Get-ZertoProtectedVm.md
@@ -238,8 +238,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -250,4 +249,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Protected VMs End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.088.html#)

--- a/docs/Get-ZertoRecoveryReport.md
+++ b/docs/Get-ZertoRecoveryReport.md
@@ -175,8 +175,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -187,4 +186,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Recovery Report End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.055.html#)

--- a/docs/Get-ZertoResourcesReport.md
+++ b/docs/Get-ZertoResourcesReport.md
@@ -10,7 +10,6 @@ schema: 2.0.0
 ## SYNOPSIS
 The resources report API generates information about the resources that are used by the virtual machines that are recovered to the site where the report is run. If no virtual machines are recovered to the site where the report is run, the report is empty.
 
-
 ## SYNTAX
 
 ### main (Default)
@@ -305,8 +304,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -317,4 +315,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Resources Report End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.058.html#)

--- a/docs/Get-ZertoServiceProfile.md
+++ b/docs/Get-ZertoServiceProfile.md
@@ -72,8 +72,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -84,4 +83,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Service Profile End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.062.html#)

--- a/docs/Get-ZertoTask.md
+++ b/docs/Get-ZertoTask.md
@@ -186,8 +186,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -198,4 +197,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Task End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.076.html#)

--- a/docs/Get-ZertoUnprotectedVm.md
+++ b/docs/Get-ZertoUnprotectedVm.md
@@ -13,7 +13,7 @@ Returns all virtual machines at the site not currently protected in a virtual pr
 ## SYNTAX
 
 ```
-Get-ZertoUnprotectedVm
+Get-ZertoUnprotectedVm [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,6 +30,9 @@ Returns all virtual machines at the site not currently protected in a virtual pr
 
 ## PARAMETERS
 
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
 ## INPUTS
 
 ### None
@@ -39,4 +42,5 @@ Returns all virtual machines at the site not currently protected in a virtual pr
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Virtualization Sites End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.082.html#)

--- a/docs/Get-ZertoVirtualizationSite.md
+++ b/docs/Get-ZertoVirtualizationSite.md
@@ -248,8 +248,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -260,4 +259,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Virtualization Sites End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.082.html#)

--- a/docs/Get-ZertoVolume.md
+++ b/docs/Get-ZertoVolume.md
@@ -128,8 +128,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -140,4 +139,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Volumes End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.094.html#)

--- a/docs/Get-ZertoVpg.md
+++ b/docs/Get-ZertoVpg.md
@@ -8,68 +8,80 @@ schema: 2.0.0
 # Get-ZertoVpg
 
 ## SYNOPSIS
+
 Returns information about VPGs
 
 ## SYNTAX
 
 ### main (Default)
-```
+
+```PowerShell
 Get-ZertoVpg [<CommonParameters>]
 ```
 
 ### stats
-```
+
+```PowerShell
 Get-ZertoVpg -protectionGroupIdentifier <String[]> [-checkpointsStats] [<CommonParameters>]
 ```
 
 ### checkpoints
-```
-Get-ZertoVpg -protectionGroupIdentifier <String[]> [-checkpoints] [-startDate <String>] [-endDate <String>]
- [<CommonParameters>]
+
+```PowerShell
+Get-ZertoVpg -protectionGroupIdentifier <String[]> [-checkpoints] [-startDate <String>] [-endDate <String>] [<CommonParameters>]
 ```
 
 ### protectionGroupIdentifier
-```
+
+```PowerShell
 Get-ZertoVpg -protectionGroupIdentifier <String[]> [<CommonParameters>]
 ```
 
 ### entityTypes
-```
+
+```PowerShell
 Get-ZertoVpg [-entityTypes] [<CommonParameters>]
 ```
 
 ### failoverCommitPolicies
-```
+
+```PowerShell
 Get-ZertoVpg [-failoverCommitPolicies] [<CommonParameters>]
 ```
 
 ### failoverShutdownPolicies
-```
+
+```PowerShell
 Get-ZertoVpg [-failoverShutdownPolicies] [<CommonParameters>]
 ```
 
 ### priorities
-```
+
+```PowerShell
 Get-ZertoVpg [-priorities] [<CommonParameters>]
 ```
 
 ### retentionPolicies
-```
+
+```PowerShell
 Get-ZertoVpg [-retentionPolicies] [<CommonParameters>]
 ```
 
 ### statuses
-```
+
+```PowerShell
 Get-ZertoVpg [-statuses] [<CommonParameters>]
 ```
 
 ### subStatuses
-```
+
+```PowerShell
 Get-ZertoVpg [-subStatuses] [<CommonParameters>]
 ```
 
 ### filter
-```
+
+```PowerShell
 Get-ZertoVpg [-name <String>] [-status <String>] [-subStatus <String>] [-protectedSiteType <String>]
  [-recoverySiteType <String>] [-protectedSiteIdentifier <String>] [-recoverySiteIdentifier <String>]
  [-organizationName <String>] [-zorgIdentifier <String>] [-priority <String>]
@@ -77,18 +89,21 @@ Get-ZertoVpg [-name <String>] [-status <String>] [-subStatus <String>] [-protect
 ```
 
 ## DESCRIPTION
+
 returns information about VPGs
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
 PS C:\> Get-ZertoVpg
 ```
 
 Returns information about all VPGs in the site processing the request
 
-### Example 1
+### Example 2
+
 ```powershell
 PS C:\> Get-ZertoVpg -name "MyVpg"
 ```
@@ -98,6 +113,7 @@ Returns information about VPG with the name "MyVpg"
 ## PARAMETERS
 
 ### -backupEnabled
+
 If backup is enabled.
 
 ```yaml
@@ -113,6 +129,7 @@ Accept wildcard characters: False
 ```
 
 ### -checkpoints
+
 Return checkpoints for the selected Virtual Protection Group.
 
 ```yaml
@@ -128,6 +145,7 @@ Accept wildcard characters: False
 ```
 
 ### -checkpointsStats
+
 Return earliest and latest checkpoints for the selected Virtual Protection Group
 
 ```yaml
@@ -143,6 +161,7 @@ Accept wildcard characters: False
 ```
 
 ### -endDate
+
 Return checkpoints before the specified start date.
 Valid formats include: 'yyyy-MM-ddTHH:mm:ss.fffZ', 'yyyy-MM-ddTHH:mm:ssZ', 'yyyy-MM-ddTHH:mmZ', 'yyyy-MM-ddTHHZ', 'yyyy-MM-dd', 'yyyy-MM', 'yyyy'.
 Adding Z to the end of the time sets the time to UTC.
@@ -160,6 +179,7 @@ Accept wildcard characters: False
 ```
 
 ### -entityTypes
+
 Return Valid VPG entityTypes
 
 ```yaml
@@ -175,6 +195,7 @@ Accept wildcard characters: False
 ```
 
 ### -failoverCommitPolicies
+
 Valid Failover Commit Policies
 
 ```yaml
@@ -190,6 +211,7 @@ Accept wildcard characters: False
 ```
 
 ### -failoverShutdownPolicies
+
 Valid Failover Shutdown Policies
 
 ```yaml
@@ -205,6 +227,7 @@ Accept wildcard characters: False
 ```
 
 ### -name
+
 The name of the VPG.
 
 ```yaml
@@ -220,6 +243,7 @@ Accept wildcard characters: False
 ```
 
 ### -organizationName
+
 The ZORG for this VPG.
 
 ```yaml
@@ -235,6 +259,7 @@ Accept wildcard characters: False
 ```
 
 ### -priorities
+
 Valid VPG priorities
 
 ```yaml
@@ -250,6 +275,7 @@ Accept wildcard characters: False
 ```
 
 ### -priority
+
 The VPG priority.
 Possible values are: '0' or 'Low', '1' or 'Medium', '2' or 'High'
 
@@ -266,6 +292,7 @@ Accept wildcard characters: False
 ```
 
 ### -protectedSiteIdentifier
+
 The identifier of the protected site where the VPG virtual machines are protected.
 
 ```yaml
@@ -281,6 +308,7 @@ Accept wildcard characters: False
 ```
 
 ### -protectedSiteType
+
 The protected site environment.
 This filter behaves in the same way as the sourceType filter.
 Please see Zerto API Documentation for vaild values and discriptions.
@@ -298,6 +326,7 @@ Accept wildcard characters: False
 ```
 
 ### -protectionGroupIdentifier
+
 The identifier(s) of the Virtual Protection Group to return
 
 ```yaml
@@ -313,6 +342,7 @@ Accept wildcard characters: False
 ```
 
 ### -recoverySiteIdentifier
+
 The identifier of the protected site where the VPG virtual machines are recovered.
 
 ```yaml
@@ -328,6 +358,7 @@ Accept wildcard characters: False
 ```
 
 ### -recoverySiteType
+
 The recovery site environment.
 This filter behaves in the same way as the sourceType filter.
 Please see Zerto API Documentation for vaild values and discriptions.
@@ -345,6 +376,7 @@ Accept wildcard characters: False
 ```
 
 ### -retentionPolicies
+
 Valid retention policies
 
 ```yaml
@@ -360,6 +392,7 @@ Accept wildcard characters: False
 ```
 
 ### -serviceProfileIdentifier
+
 The identifier of the service profile to use for the VPG when a Zerto Cloud Manager is used.
 
 ```yaml
@@ -375,6 +408,7 @@ Accept wildcard characters: False
 ```
 
 ### -startDate
+
 Return checkpoints after the specified start date.
 Valid formats include: 'yyyy-MM-ddTHH:mm:ss.fffZ', 'yyyy-MM-ddTHH:mm:ssZ', 'yyyy-MM-ddTHH:mmZ', 'yyyy-MM-ddTHHZ', 'yyyy-MM-dd', 'yyyy-MM', 'yyyy'.
 Adding Z to the end of the time sets the time to UTC.
@@ -392,6 +426,7 @@ Accept wildcard characters: False
 ```
 
 ### -status
+
 The status of the VPG.
 Please use 'Get-ZertoVpg -statuses' for valid values
 
@@ -408,6 +443,7 @@ Accept wildcard characters: False
 ```
 
 ### -statuses
+
 Valid VPG statuses
 
 ```yaml
@@ -423,6 +459,7 @@ Accept wildcard characters: False
 ```
 
 ### -subStatus
+
 The substatus of the VPG.
 Please use 'Get-ZertoVpg -substatuses' for valid values
 
@@ -439,6 +476,7 @@ Accept wildcard characters: False
 ```
 
 ### -subStatuses
+
 Valid VPG sub statuses
 
 ```yaml
@@ -454,6 +492,7 @@ Accept wildcard characters: False
 ```
 
 ### -zorgIdentifier
+
 The internal identifier for the ZORG.
 
 ```yaml
@@ -469,14 +508,19 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None
+
 ## OUTPUTS
 
 ### System.Object
+
+JSON data returned from the API as a PowerShell object containing settings for the selected VPG(s).
+
 ## NOTES
 
 ## RELATED LINKS

--- a/docs/Get-ZertoVpg.md
+++ b/docs/Get-ZertoVpg.md
@@ -469,8 +469,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -481,4 +480,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Get-ZertoVpgSetting.md
+++ b/docs/Get-ZertoVpgSetting.md
@@ -436,8 +436,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -448,4 +447,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG Settings End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.108.html#)

--- a/docs/Get-ZertoVra.md
+++ b/docs/Get-ZertoVra.md
@@ -241,8 +241,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -253,4 +252,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VRA End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.117.html#)

--- a/docs/Get-ZertoZorg.md
+++ b/docs/Get-ZertoZorg.md
@@ -59,8 +59,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -71,4 +70,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API ZOrg End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.126.html#)

--- a/docs/Get-ZertoZsspSession.md
+++ b/docs/Get-ZertoZsspSession.md
@@ -52,8 +52,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -64,4 +63,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API ZSSP Session End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.132.html#)

--- a/docs/Install-ZertoVra.md
+++ b/docs/Install-ZertoVra.md
@@ -215,8 +215,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -227,4 +226,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VRA End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.117.html#)

--- a/docs/Invoke-ZertoFailover.md
+++ b/docs/Invoke-ZertoFailover.md
@@ -173,8 +173,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -185,4 +184,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Invoke-ZertoFailoverCommit.md
+++ b/docs/Invoke-ZertoFailoverCommit.md
@@ -68,8 +68,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -80,4 +79,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Invoke-ZertoFailoverRollback.md
+++ b/docs/Invoke-ZertoFailoverRollback.md
@@ -46,8 +46,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -58,4 +57,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Invoke-ZertoForceSync.md
+++ b/docs/Invoke-ZertoForceSync.md
@@ -46,8 +46,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -58,4 +57,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Invoke-ZertoMove.md
+++ b/docs/Invoke-ZertoMove.md
@@ -162,8 +162,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -174,4 +173,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Invoke-ZertoMoveCommit.md
+++ b/docs/Invoke-ZertoMoveCommit.md
@@ -80,8 +80,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -92,4 +91,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Invoke-ZertoMoveRollback.md
+++ b/docs/Invoke-ZertoMoveRollback.md
@@ -46,8 +46,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -58,4 +57,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Remove-ZertoVpg.md
+++ b/docs/Remove-ZertoVpg.md
@@ -8,21 +8,32 @@ schema: 2.0.0
 # Remove-ZertoVpg
 
 ## SYNOPSIS
+
 Deletes a Zerto Virtual Protection Group
 
 ## SYNTAX
 
-```
-Remove-ZertoVpg [-vpgName] <String> [-keepRecoveryVolumes <Boolean>] [-force <Boolean>] [-WhatIf] [-Confirm]
+### vpgIdentifier (Default)
+
+```PowerShell
+Remove-ZertoVpg -vpgidentifier <String[]> [-keepRecoveryVolumes] [-force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
+### vpgName
+
+```PowerShell
+Remove-ZertoVpg [-vpgName] <String[]> [-keepRecoveryVolumes] [-force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
 ## DESCRIPTION
+
 Deletes a Zerto Virtual Protection Group.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
 PS C:\> Remove-ZertoVpg -vpgName "MyVpg"
 ```
@@ -30,19 +41,37 @@ PS C:\> Remove-ZertoVpg -vpgName "MyVpg"
 Deletes Zerto Virtual Protection Group named "MyVpg". Recovery volumes at the recovery site will be deleted.
 
 ### Example 2
+
 ```powershell
-PS C:\> Remove-ZertoVpg -vpgName "MyVpg" -keepRecoveryVolumes
+PS C:\> Remove-ZertoVpg -vpgName "MyVpg", "MyOtherVpg" -keepRecoveryVolumes
 ```
 
-Deletes Zerto Virtual Protection Group named "MyVpg". Recovery volumes at the recovery site will be retained.
+Deletes Zerto Virtual Protection Groups named "MyVpg" and "MyOtherVpg." Recovery volumes at the recovery site will be retained for both VPGs.
+
+### Example 3
+
+```powershell
+PS C:\> Remove-ZertoVpg -vpgIdentifier "MyVpgIdentifier" -keepRecoveryVolumes
+```
+
+Deletes Zerto Virtual Protection Group with vpgIdentifier "MyVpgIdentifier". Recovery volumes at the recovery site will be retained.
+
+### Example 4
+
+```powershell
+PS C:\> Get-ZertoVpg -recoverySiteIdentifier "MyRecoverySiteIdentifier" | Remove-ZertoVpg
+```
+
+Uses the `Get-ZertoVpg` function to get all VPGs currently being protected to recovery site with identifier "MyRecoverySiteIdentifier." This information is piped into the `Remove-ZertoVpg` function and will remove all VPGs being protected to the specified recovery site.
 
 ## PARAMETERS
 
 ### -force
-Use this parameter to force delete the VPG, by setting this parameter equal to true.
+
+Use this switch to force delete the VPG. If unused, a non-forced remove vpg operation will be executed.
 
 ```yaml
-Type: Boolean
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
@@ -54,10 +83,11 @@ Accept wildcard characters: False
 ```
 
 ### -keepRecoveryVolumes
-Use this parameter to keep the recovery volumes at the target site, by setting it to True.  If the virtual machines in the deleted VPG are re-protected, these volumes can be used as pre-seed volumes to speed up the initial synchronization of the new VPG. Default is to remove Recovery Volumes
+
+Use this switch to keep the recovery volumes at the target site.  If the virtual machines in the deleted VPG are re-protected, these volumes can be used as pre-seed volumes to speed up the initial synchronization of the new VPG. If this switch is not set, recovery volumes will not be retained. If required to be retained, get the path to these volumes prior to the deletion to use as pre-seed volumes for an easier operation.
 
 ```yaml
-Type: Boolean
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
@@ -68,22 +98,40 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -vpgName
-Name of the VPG to delete.
+### -vpgidentifier
+
+vpgIdentifier(s) of the VPG(s) to delete.
 
 ```yaml
-Type: String
-Parameter Sets: (All)
+Type: String[]
+Parameter Sets: vpgIdentifier
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -vpgName
+
+Name(s) of the VPG(s) to delete.
+
+```yaml
+Type: String[]
+Parameter Sets: vpgName
 Aliases:
 
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -99,6 +147,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -115,14 +164,19 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None
+
 ## OUTPUTS
 
 ### System.Object
+
+Task Identifier of the Remove operation
+
 ## NOTES
 
 ## RELATED LINKS

--- a/docs/Resume-ZertoVpg.md
+++ b/docs/Resume-ZertoVpg.md
@@ -46,8 +46,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -58,4 +57,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Save-ZertoVpgSettings.md
+++ b/docs/Save-ZertoVpgSettings.md
@@ -88,4 +88,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG Settings End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.108.html#)

--- a/docs/Set-ZertoAlert.md
+++ b/docs/Set-ZertoAlert.md
@@ -120,8 +120,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -132,4 +131,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API Alerts End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/index.html#page/RestfulAPIs%2FStatusAPIs.5.009.html%23)

--- a/docs/Set-ZertoLicense.md
+++ b/docs/Set-ZertoLicense.md
@@ -77,8 +77,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -89,4 +88,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API License Information](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.034.html#)

--- a/docs/Start-ZertoCloneVpg.md
+++ b/docs/Start-ZertoCloneVpg.md
@@ -95,8 +95,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -107,4 +106,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Start-ZertoFailoverTest.md
+++ b/docs/Start-ZertoFailoverTest.md
@@ -79,8 +79,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -91,4 +90,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Stop-ZertoCloneVpg.md
+++ b/docs/Stop-ZertoCloneVpg.md
@@ -46,8 +46,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -58,4 +57,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Stop-ZertoFailoverTest.md
+++ b/docs/Stop-ZertoFailoverTest.md
@@ -79,8 +79,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -91,4 +90,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Suspend-ZertoVpg.md
+++ b/docs/Suspend-ZertoVpg.md
@@ -46,8 +46,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -58,4 +57,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VPG End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.100.html#)

--- a/docs/Uninstall-ZertoVra.md
+++ b/docs/Uninstall-ZertoVra.md
@@ -46,8 +46,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
-For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -58,4 +57,5 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto REST API VRA End Point Documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/RestfulAPIs/StatusAPIs.5.117.html#)


### PR DESCRIPTION
Fixes #10 

This allows Remove-ZertoVpg to process multiple VPGs at once by passing in an array of either VpgNames or VpgIdentifiers. This can now also be used in conjunction with `Get-ZertoVpg` then piping the output from this command directly into `Remove-ZertoVpg`. When executed this way, any switches selected will be applied to all VPGs and will remove based on vpgIdentifier.