### PR TITLE
Alias updates

### DIFF
--- a/Tests/Public/External-Help.Tests.ps1
+++ b/Tests/Public/External-Help.Tests.ps1
@@ -1,0 +1,10 @@
+$filePath = (Split-Path -Parent $MyInvocation.MyCommand.Path) -replace 'Tests', 'ZertoApiWrapper'
+$publicFiles = Get-ChildItem "$filePath" -File
+
+describe "External Help Present" {
+    foreach ($file in $publicFiles) {
+        it "External Help File Defined" {
+            Get-Content -Path $file.fullName -First 1 | should be "<# .ExternalHelp ./en-us/ZertoApiWrapper-help.xml #>"
+        }
+    }
+}

--- a/ZertoApiWrapper/Public/Connect-ZertoServer.ps1
+++ b/ZertoApiWrapper/Public/Connect-ZertoServer.ps1
@@ -7,10 +7,12 @@ function Connect-ZertoServer {
             HelpMessage = "IP address or FQDN of your Zerto Management Server"
         )]
         [ValidateNotNullOrEmpty()]
+        [Alias("server", "zvm")]
         [string]$zertoServer,
         [Parameter(
             HelpMessage = "Zerto Virtual Manager management port. Default value is 9669."
         )]
+        [Alias("port")]
         [string]$zertoPort = "9669",
         [Parameter(
             Mandatory = $true,

--- a/ZertoApiWrapper/Public/Edit-ZertoVra.ps1
+++ b/ZertoApiWrapper/Public/Edit-ZertoVra.ps1
@@ -6,6 +6,7 @@ function Edit-ZertoVra {
             Mandatory = $true,
             HelpMessage = "Identifier of the VRA to be updated."
         )]
+        [Alias("vraId")]
         [string]$vraIdentifier,
         [Parameter(
             HelpMessage = "Bandwidth group to assign to the VRA. If unspecified will not modify current assignment"

--- a/ZertoApiWrapper/Public/Export-ZertoVpg.ps1
+++ b/ZertoApiWrapper/Public/Export-ZertoVpg.ps1
@@ -1,3 +1,4 @@
+<# .ExternalHelp ./en-us/ZertoApiWrapper-help.xml #>
 function Export-ZertoVpg {
     [cmdletbinding()]
     param(

--- a/ZertoApiWrapper/Public/Get-ZertoAlert.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoAlert.ps1
@@ -42,16 +42,19 @@ function Get-ZertoAlert {
             ParameterSetName = "filter",
             HelpMessage = "Returns alerts for the specified vraIdentifier"
         )]
+        [Alias("vpgId")]
         [string]$vpgIdentifier,
         [Parameter(
             ParameterSetName = "filter",
             HelpMessage = "Returns alerts for the specified siteIdentifier"
         )]
+        [Alias("siteId")]
         [string]$siteIdentifier,
         [Parameter(
             ParameterSetName = "filter",
             HelpMessage = "Returns alerts for the specified zorgIdentifier"
         )]
+        [Alias("zorgId")]
         [string]$zorgIdentifier,
         [Parameter(
             ParameterSetName = "filter",
@@ -62,6 +65,7 @@ function Get-ZertoAlert {
             ParameterSetName = "filter",
             HelpMessage = "Returns alerts for the specified helpIdentifier"
         )]
+        [Alias("helpId")]
         [string]$helpIdentifier,
         [Parameter(
             ParameterSetName = "filter",

--- a/ZertoApiWrapper/Public/Get-ZertoDatastore.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoDatastore.ps1
@@ -2,6 +2,7 @@
 function Get-ZertoDatastore {
     [cmdletbinding( DefaultParameterSetName = "main" )]
     param(
+        [Alias("datastoreId")]
         [Parameter(
             ParameterSetName = "datastoreIdentifier",
             HelpMessage = "datastoreIdentifier or array of datastoreIdentifiers to be queried"

--- a/ZertoApiWrapper/Public/Get-ZertoEvent.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoEvent.ps1
@@ -47,8 +47,9 @@ function Get-ZertoEvent {
         [string]$zorgIdentifier,
         [Parameter(
             ParameterSetName = "filter",
-            HelpMessage = "The type of entity for which you wish to return results. Possible Values are: '0' or 'VPG', '1' or 'VRA', '2' or 'Unknown', or '3' or 'Site'"
+            HelpMessage = "The type of entity for which you wish to return results. Possible Values are: 'VPG', 'VRA', 'Unknown', or 'Site'"
         )]
+        [ValidateSet("VPG", "VRA", "Unknown", "Site")]
         [string]$entityType,
         [Parameter(
             ParameterSetName = "filter",
@@ -57,13 +58,15 @@ function Get-ZertoEvent {
         [string]$userName,
         [Parameter(
             ParameterSetName = "filter",
-            HelpMessage = "The type of event to return. This filter behaves in the same way as the eventCategory filter. Possible Values are: Possible Values are: '0' or 'All', '1' or 'Events', '2' or 'Alerts'"
+            HelpMessage = "The type of event to return. This filter behaves in the same way as the eventCategory filter. Possible Values are: Possible Values are: 'All', 'Events', 'Alerts'"
         )]
+
         [string]$category,
         [Parameter(
             ParameterSetName = "filter",
-            HelpMessage = " This filter behaves in the same way as the category filter. If both category and eventCategory filters are specified, only the category filter value is used and the eventCategory filter value is ignored. The type of event to return. Possible Values are: '0' or 'All', '1' or 'Events', '2' or 'Alerts'"
+            HelpMessage = " This filter behaves in the same way as the category filter. If both category and eventCategory filters are specified, only the category filter value is used and the eventCategory filter value is ignored. The type of event to return. Possible Values are: 'All', 'Events', 'Alerts'"
         )]
+        [ValidateSet("All", "Events", "Alerts")]
         [string]$eventCategory,
         [Parameter(
             ParameterSetName = "filter",

--- a/ZertoApiWrapper/Public/Get-ZertoEvent.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoEvent.ps1
@@ -16,11 +16,13 @@ function Get-ZertoEvent {
             ParameterSetName = "filter",
             HelpMessage = "The name of the VPG for which you want to return events."
         )]
+        [Alias("vpgName")]
         [string]$vpg,
         [Parameter(
             ParameterSetName = "filter",
             HelpMessage = "The identifier of the VPG for which you want to return events."
         )]
+        [Alias("vpgId")]
         [string]$vpgIdentifier,
         [Parameter( ParameterSetName = "filter",
             HelpMessage = "The type of event. For the description of events, refer to the Zerto Virtual Replication documentation about alerts and events. Please see Zerto API Documentation for possible values."
@@ -35,11 +37,13 @@ function Get-ZertoEvent {
             ParameterSetName = "filter",
             HelpMessage = "The internal site identifier for which you want to return events."
         )]
+        [Alias("siteId")]
         [string]$siteIdentifier,
         [Parameter(
             ParameterSetName = "filter",
             HelpMessage = "The identifier of the ZORG, Zerto organization, defined in the Zerto Cloud Manager for which you want to return results."
         )]
+        [Alias("zorgId")]
         [string]$zorgIdentifier,
         [Parameter(
             ParameterSetName = "filter",
@@ -65,6 +69,7 @@ function Get-ZertoEvent {
             ParameterSetName = "filter",
             HelpMessage = "The internal alert identifier for the Event"
         )]
+        [Alias("alertId")]
         [string]$alertIdentifier,
         [Parameter(
             ParameterSetName = "eventId",

--- a/ZertoApiWrapper/Public/Get-ZertoPeerSite.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoPeerSite.ps1
@@ -15,6 +15,7 @@ function Get-ZertoPeerSite {
             ValueFromPipelineByPropertyName = $true,
             HelpMessage = "The identifier(s) of the peer site(s) for which information is to be returned."
         )]
+        [Alias("siteId")]
         [string[]]$siteIdentifier,
         [Parameter(
             ParameterSetName = "filter",

--- a/ZertoApiWrapper/Public/Get-ZertoProtectedVm.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoProtectedVm.ps1
@@ -9,6 +9,7 @@ function Get-ZertoProtectedVm {
             ValueFromPipelineByPropertyName = $true,
             HelpMessage = "vmIdentifier(s) for which to return information"
         )]
+        [Alias("vmId")]
         [string[]]$vmIdentifier,
         [Parameter(
             ParameterSetName = "filter",
@@ -54,11 +55,13 @@ function Get-ZertoProtectedVm {
             ParameterSetName = "filter",
             HelpMessage = "The identifier of the protected site where the VPG virtual machines are protected."
         )]
+        [Alias("protectedSiteId")]
         [string]$protectedSiteIdentifier,
         [Parameter(
             ParameterSetName = "filter",
             HelpMessage = "The identifier of the recovery site where the VPG virtual machines are recovered."
         )]
+        [Alias("recoverySiteId")]
         [string]$recoverySiteIdentifier
     )
 

--- a/ZertoApiWrapper/Public/Get-ZertoProtectedVm.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoProtectedVm.ps1
@@ -38,8 +38,9 @@ function Get-ZertoProtectedVm {
         [string]$organizationName,
         [Parameter(
             ParameterSetName = "filter",
-            HelpMessage = "The priority specified for the VPG. Possible values are: '0' or 'Low', '1' or 'Medium', '2' or 'High'"
+            HelpMessage = "The priority specified for the VPG. Possible values are: 'Low', 'Medium', or 'High'"
         )]
+        [ValidateSet("Low", "Medium", "High")]
         [string]$priority,
         [Parameter(
             ParameterSetName = "filter",

--- a/ZertoApiWrapper/Public/Get-ZertoRecoveryReport.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoRecoveryReport.ps1
@@ -36,6 +36,7 @@ function Get-ZertoRecoveryReport {
             ParameterSetName = "filter",
             HelpMessage = "The type of recovery operations. Possible values are: 'Failover', 'Failover Test', or 'Move'"
         )]
+        [ValidateSet("Failover", "Failover Test", "Move")]
         [string]$recoveryType,
         [Parameter(
             ParameterSetName = "filter",

--- a/ZertoApiWrapper/Public/Get-ZertoServiceProfile.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoServiceProfile.ps1
@@ -6,6 +6,7 @@ function Get-ZertoServiceProfile {
             ParameterSetName = "siteIdentifier",
             HelpMessage = "The identifier of the site for which service profiles should be returned."
         )]
+        [Alias("siteId")]
         [string]$siteIdentifier,
         [Parameter(
             ParameterSetName = "serviceProfileId",

--- a/ZertoApiWrapper/Public/Get-ZertoTask.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoTask.ps1
@@ -6,6 +6,7 @@ function Get-ZertoTask {
             ParameterSetName = "taskIdentifier",
             HelpMessage = "The identifier(s) for which task information is to be returned."
         )]
+        [Alias("taskId")]
         [string[]]$taskIdentifier,
         [Parameter(
             ParameterSetName = "types",

--- a/ZertoApiWrapper/Public/Get-ZertoTask.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoTask.ps1
@@ -40,8 +40,9 @@ function Get-ZertoTask {
         [string]$type,
         [Parameter(
             ParameterSetName = "filter",
-            HelpMessage = "The status of the task. Possible values are: '1' or 'InProgress', '3' or 'Paused', '4' or 'Failed', '6' or 'Completed', '7' or 'Cancelling'"
+            HelpMessage = "The status of the task. Possible values are: 'InProgress', 'Paused', 'Failed', 'Completed', or 'Cancelling'"
         )]
+        [ValidateSet("InProgress", "Paused", "Failed", "Completed", "Cancelling")]
         [string]$status
     )
 

--- a/ZertoApiWrapper/Public/Get-ZertoVirtualizationSite.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoVirtualizationSite.ps1
@@ -52,6 +52,7 @@ function Get-ZertoVirtualizationSite {
             Mandatory = $true,
             HelpMessage = "The identifier of the Zerto Virtual Manager site."
         )]
+        [Alias("siteId")]
         [string]$siteIdentifier,
         [Parameter(
             ParameterSetName = "datastoreClusters",
@@ -81,6 +82,7 @@ function Get-ZertoVirtualizationSite {
             Mandatory = $false,
             HelpMessage = "The identifier of the host at the selected site to return information for only one host."
         )]
+        [Alias("hostId")]
         [string]$hostIdentifier,
         [Parameter(
             ParameterSetName = "folders",

--- a/ZertoApiWrapper/Public/Get-ZertoVolume.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoVolume.ps1
@@ -11,21 +11,25 @@ function Get-ZertoVolume {
             ParameterSetName = "filter",
             HelpMessage = "The identifier of the VPG."
         )]
+        [Alias("vpgId")]
         [string]$vpgIdentifier,
         [Parameter(
             ParameterSetName = "filter",
             HelpMessage = "The identifier of the datastore."
         )]
+        [Alias("datastoreId", "dsId")]
         [string]$datastoreIdentifier,
         [Parameter(
             ParameterSetName = "filter",
             HelpMessage = "The identifier of the protected virtual machine."
         )]
+        [Alias("protectedVmId")]
         [string]$protectedVmIdentifier,
         [Parameter(
             ParameterSetName = "filter",
             HelpMessage = "The identifier of the owning virtual machine."
         )]
+        [Alias("owningVmId")]
         [string]$owningVmIdentifier
     )
 

--- a/ZertoApiWrapper/Public/Get-ZertoVpg.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoVpg.ps1
@@ -17,6 +17,7 @@ function Get-ZertoVpg {
             Mandatory = $true,
             HelpMessage = "The identifier(s) of the Virtual Protection Group to return"
         )]
+        [Alias("vpgId", "protectionGroupId", "pgId")]
         [string[]]$protectionGroupIdentifier,
         [Parameter(
             ParameterSetName = "checkpoints",

--- a/ZertoApiWrapper/Public/Get-ZertoVpg.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoVpg.ps1
@@ -130,8 +130,9 @@ function Get-ZertoVpg {
         [string]$zorgIdentifier,
         [Parameter(
             ParameterSetName = "filter",
-            HelpMessage = "The VPG priority. Possible values are: '0' or 'Low', '1' or 'Medium', '2' or 'High'"
+            HelpMessage = "The VPG priority. Possible values are: 'Low', 'Medium', 'High'"
         )]
+        [ValidateSet("Low", "Medium", "High")]
         [string]$priority,
         [Parameter(
             ParameterSetName = "filter",

--- a/ZertoApiWrapper/Public/Get-ZertoVpgSetting.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoVpgSetting.ps1
@@ -131,6 +131,7 @@ function Get-ZertoVpgSetting {
             Mandatory = $true,
             HelpMessage = "The identifier of the VPG settings object for which information is retrieved."
         )]
+        [Alias("vpgSettingsId", "settingsId")]
         [string]$vpgSettingsIdentifier,
         [Parameter(
             ParameterSetName = "backup",
@@ -229,6 +230,7 @@ function Get-ZertoVpgSetting {
             Mandatory = $true,
             HelpMessage = "VM Identifier"
         )]
+        [Alias("vmId")]
         [string]$vmIdentifier,
         [Parameter(
             ParameterSetName = "nics",
@@ -241,6 +243,7 @@ function Get-ZertoVpgSetting {
             Mandatory = $true,
             HelpMessage = "Return NIC information for specified NIC of the specified VM"
         )]
+        [Alias("nicId")]
         [string]$nicIdentifier,
         [Parameter(
             ParameterSetName = "volumes",
@@ -253,6 +256,7 @@ function Get-ZertoVpgSetting {
             Mandatory = $true,
             HelpMessage = "Return volume information for the specified volume of the specified VM"
         )]
+        [Alias("volumeId")]
         [string]$volumeIdentifier
     )
 

--- a/ZertoApiWrapper/Public/Get-ZertoVra.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoVra.ps1
@@ -18,6 +18,7 @@ function Get-ZertoVra {
             ParameterSetName = "vraIdentifier",
             HelpMessage = "Returns information for provided VRA identifier(s)"
         )]
+        [Alias("vraId")]
         [string[]]$vraIdentifier,
         [Parameter(
             ParameterSetName = "filter",

--- a/ZertoApiWrapper/Public/Get-ZertoZorg.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoZorg.ps1
@@ -6,6 +6,7 @@ function Get-ZertoZorg {
             ParameterSetName = "zorgIdentifier",
             HelpMessage = "Identifier(s) of the ZORG."
         )]
+        [Alias("zorgId")]
         [string[]]$zorgIdentifier
     )
 

--- a/ZertoApiWrapper/Public/Get-ZertoZsspSession.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoZsspSession.ps1
@@ -6,6 +6,7 @@ function Get-ZertoZsspSession {
             ParameterSetName = "zsspSessionIdentifier",
             HelpMessage = "ZSSP Session Id(s) to get information."
         )]
+        [Alias("zsspSessionId")]
         [string[]]$zsspSessionIdentifier
     )
 

--- a/ZertoApiWrapper/Public/Import-ZertoVpg.ps1
+++ b/ZertoApiWrapper/Public/Import-ZertoVpg.ps1
@@ -1,3 +1,4 @@
+<# .ExternalHelp ./en-us/ZertoApiWrapper-help.xml #>
 function Import-ZertoVpg {
     [cmdletbinding()]
     param(

--- a/ZertoApiWrapper/Public/Install-ZertoVra.ps1
+++ b/ZertoApiWrapper/Public/Install-ZertoVra.ps1
@@ -1,5 +1,5 @@
-#TODO - Add ability to installed with root password.
 <# .ExternalHelp ./en-us/ZertoApiWrapper-help.xml #>
+#TODO - Add ability to installed with root password.
 function Install-ZertoVra {
     [cmdletbinding( SupportsShouldProcess = $true )]
     param(

--- a/ZertoApiWrapper/Public/Invoke-ZertoFailover.ps1
+++ b/ZertoApiWrapper/Public/Invoke-ZertoFailover.ps1
@@ -10,6 +10,7 @@ function Invoke-ZertoFailover {
         [Parameter(
             HelpMessage = "Checkpoint Identifier to use as the Point-In-Time to rollback to."
         )]
+        [Alias("checkpointId")]
         [string]$checkpointIdentifier,
         [Parameter(
             HelpMessage = "0: After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.

--- a/ZertoApiWrapper/Public/Invoke-ZertoFailover.ps1
+++ b/ZertoApiWrapper/Public/Invoke-ZertoFailover.ps1
@@ -13,11 +13,12 @@ function Invoke-ZertoFailover {
         [Alias("checkpointId")]
         [string]$checkpointIdentifier,
         [Parameter(
-            HelpMessage = "0: After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.
-            1: After the seconds specified in the commitValue setting have elapsed, the failover continues, committing the virtual machines in the recovery site.
-            2: The virtual machines in the VPG being failed over remain in the Before Commit state until either they are committed with Commit a failover, or rolled back with Roll back a failover.
+            HelpMessage = "'Rollback': After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.
+            'Commit': After the seconds specified in the commitValue setting have elapsed, the failover continues, committing the virtual machines in the recovery site.
+            'None': The virtual machines in the VPG being failed over remain in the Before Commit state until either they are committed with Commit a failover, or rolled back with Roll back a failover.
             Default is the Site Settings setting."
         )]
+        [ValidateSet("Rollback", "Commit", "None")]
         [string]$commitPolicy,
         [Parameter(
             HelpMessage = "The amount of time in seconds the failover waits in a Before Commit state to enable checking that the failover is as required before performing the commitPolicy setting. Default is the Site Setting"
@@ -28,6 +29,7 @@ function Invoke-ZertoFailover {
         1: If the protected virtual machines have VMware Tools or Microsoft Integration Services available, the virtual machines are gracefully shut down, otherwise the failover operation fails. This is similar to performing a Move operation to a specified checkpoint.
         2: The protected virtual machines are forcibly shut down before starting the failover. If the protected virtual machines have VMware Tools or Microsoft Integration Services available, the procedure waits five minutes for the virtual machines to be gracefully shut down before forcibly powering them off. This is similar to performing a Move operation to a specified checkpoint."
         )]
+        [ValidateSet(0, 1, 2)]
         [int]$shutdownPolicy = 0,
         [Parameter(
             HelpMessage = "Time, in seconds, before VMs are forcibly turned off if the Force Shutdown option is seclected after attempting to gracefully shut down the VMs"
@@ -39,7 +41,7 @@ function Invoke-ZertoFailover {
         )]
         [bool]$reverseProtection,
         [Parameter(
-            HelpMessage = "Name(s) of VMs in the "
+            HelpMessage = "Name(s) of VMs in the VPG to failover"
         )]
         [string[]]$vmName
     )

--- a/ZertoApiWrapper/Public/Invoke-ZertoMove.ps1
+++ b/ZertoApiWrapper/Public/Invoke-ZertoMove.ps1
@@ -8,8 +8,12 @@ function Invoke-ZertoMove {
         )]
         [string[]]$vpgName,
         [Parameter(
-            HelpMessage = "The policy to use after the move enters a 'Before Commit' state. If omitted, the site settings default will be applied. Valid values are: '0' or 'Rollback', '1' or 'Commit', '2' or 'None'. Please see Zerto API Documentation for additional information."
+            HelpMessage = "'Rollback': After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.
+            'Commit': After the seconds specified in the commitValue setting have elapsed, the failover continues, committing the virtual machines in the recovery site.
+            'None': The virtual machines in the VPG being failed over remain in the Before Commit state until either they are committed with Commit a failover, or rolled back with Roll back a failover.
+            Default is the Site Settings setting."
         )]
+        [ValidateSet("Rollback", "Commit", "None")]
         [string]$commitPolicy,
         [Parameter(
             HelpMessage = "The amount of time, in seconds, the Move is in a 'Before Commit' state, before performing the commitPolicy setting. If omitted, the site settings default will be applied."

--- a/ZertoApiWrapper/Public/New-ZertoVpg.ps1
+++ b/ZertoApiWrapper/Public/New-ZertoVpg.ps1
@@ -21,7 +21,8 @@ function New-ZertoVpg {
             HelpMessage = "Name(s) of the VM(s) to be protected.",
             Mandatory = $true
         )]
-        [ValidateNotNullOrEmpty()][string[]]$protectedVm,
+        [ValidateNotNullOrEmpty()]
+        [string[]]$protectedVm,
         [Parameter(
             HelpMessage = "Name of the site where the VM(s) will be recovered",
             Mandatory = $true
@@ -100,11 +101,13 @@ function New-ZertoVpg {
         [Parameter(
             HelpMessage = "RPO alert"
         )]
-        [ValidateRange(60, 864200)][Int32]$rpoInSeconds = 300,
+        [ValidateRange(60, 864200)]
+        [Int32]$rpoInSeconds = 300,
         [Parameter(
             HelpMessage = "Minimum test interval for this VPG. Valid values are 0: Off, 43200: 1 Month, 131040: 3 Months, 262080: 6 Months, 294560: 9 Months, 252600: 12 Months"
         )]
-        [ValidateSet(0, 43200, 131040, 262080, 294560, 252600)][int]$testIntervalInMinutes = 262080,
+        [ValidateSet(0, 43200, 131040, 262080, 294560, 252600)]
+        [int]$testIntervalInMinutes = 262080,
         [Parameter(
             HelpMessage = "Service profile name to use."
         )]

--- a/ZertoApiWrapper/Public/New-ZertoVpgSettingsIdentifier.ps1
+++ b/ZertoApiWrapper/Public/New-ZertoVpgSettingsIdentifier.ps1
@@ -1,3 +1,4 @@
+<# .ExternalHelp ./en-us/ZertoApiWrapper-help.xml #>
 function New-ZertoVpgSettingsIdentifier {
     [cmdletbinding()]
     param(

--- a/ZertoApiWrapper/Public/New-ZertoVpgSettingsIdentifier.ps1
+++ b/ZertoApiWrapper/Public/New-ZertoVpgSettingsIdentifier.ps1
@@ -8,6 +8,7 @@ function New-ZertoVpgSettingsIdentifier {
             ValueFromPipeline = $true,
             ValueFromPipelineByPropertyName = $true
         )]
+        [Alias("vpgId")]
         [string]$vpgIdentifier,
         [Parameter(
             HelpMessage = "Use this switch when creating a vpgSettingsIdentifier for a new VPG",

--- a/ZertoApiWrapper/Public/Remove-ZertoVpg.ps1
+++ b/ZertoApiWrapper/Public/Remove-ZertoVpg.ps1
@@ -22,11 +22,11 @@ function Remove-ZertoVpg {
         [Parameter(
             HelpMessage = "Use this parameter to keep the recovery volumes at the target site, by setting it to True.  If the virtual machines in the deleted VPG are reprotected, these volumes can be used as preseeded volumes to speed up the initial synchronization of the new VPG. Default is to remove Recovery Volumes"
         )]
-        [switch]$keepRecoveryVolumes = $false,
+        [switch]$keepRecoveryVolumes,
         [Parameter(
             HelpMessage = "Use this parameter to force delete the VPG, by setting this parameter equal to true."
         )]
-        [switch]$force = $false
+        [switch]$force
     )
 
     begin {

--- a/ZertoApiWrapper/Public/Remove-ZertoVpg.ps1
+++ b/ZertoApiWrapper/Public/Remove-ZertoVpg.ps1
@@ -17,6 +17,7 @@ function Remove-ZertoVpg {
             ValueFromPipelineByPropertyName = $true,
             HelpMessage = "vpgIdentifier(s) of the VPG(s) to delete."
         )]
+        [Alias("vpgId")]
         [string[]]$vpgidentifier,
         [Parameter(
             HelpMessage = "Use this parameter to keep the recovery volumes at the target site, by setting it to True.  If the virtual machines in the deleted VPG are reprotected, these volumes can be used as preseeded volumes to speed up the initial synchronization of the new VPG. Default is to remove Recovery Volumes"

--- a/ZertoApiWrapper/Public/Save-ZertoVpgSettings.ps1
+++ b/ZertoApiWrapper/Public/Save-ZertoVpgSettings.ps1
@@ -10,6 +10,7 @@ function Save-ZertoVpgSettings {
             ValueFromPipeline = $true,
             ValueFromPipelineByPropertyName = $true
         )]
+        [Alias("vpgSettingsId")]
         [string]$vpgSettingsIdentifier
     )
 

--- a/ZertoApiWrapper/Public/Set-ZertoAlert.ps1
+++ b/ZertoApiWrapper/Public/Set-ZertoAlert.ps1
@@ -9,6 +9,7 @@ function Set-ZertoAlert {
             Mandatory = $true,
             HelpMessage = "Alert identifier(s) to be dismissed or undismissed."
         )]
+        [Alias("alertIdentifier")]
         [string[]]$alertId,
         [Parameter(
             ParameterSetName = "dismiss",

--- a/ZertoApiWrapper/Public/Start-ZertoCloneVpg.ps1
+++ b/ZertoApiWrapper/Public/Start-ZertoCloneVpg.ps1
@@ -10,6 +10,7 @@ function Start-ZertoCloneVpg {
         [Parameter(
             HelpMessage = "The identifier of the checkpoint to use for cloning. If unspecified, the latest checkpoint will be used."
         )]
+        [Alias("checkpointId")]
         [string]$checkpointIdentifier,
         [Parameter(
             HelpMessage = "The datastore name where the clone is to be created. If unspecified, will auto select the datastore with the most free space."

--- a/ZertoApiWrapper/Public/Start-ZertoFailoverTest.ps1
+++ b/ZertoApiWrapper/Public/Start-ZertoFailoverTest.ps1
@@ -10,6 +10,7 @@ function Start-ZertoFailoverTest {
         [Parameter(
             HelpMessage = "The identifier of the checkpoint to use for testing. If unspecified, the latest checkpoint will be used."
         )]
+        [Alias("checkpointId")]
         [string]$checkpointIdentifier,
         [Parameter(
             HelpMessage = "The name(s) of the VMs within the selected VPG you wish to test. If unspecified, all VMs in the VPG will be tested."

--- a/ZertoApiWrapper/Public/en-us/ZertoApiWrapper-help.xml
+++ b/ZertoApiWrapper/Public/en-us/ZertoApiWrapper-help.xml
@@ -285,7 +285,7 @@
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Connect-ZertoServer</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="server, zvm">
           <maml:name>zertoServer</maml:name>
           <maml:Description>
             <maml:para>IP address or FQDN of your Zerto Management Server</maml:para>
@@ -297,7 +297,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="port">
           <maml:name>zertoPort</maml:name>
           <maml:Description>
             <maml:para>Zerto Virtual Manager management port. Default value is 9669.</maml:para>
@@ -359,7 +359,7 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="port">
         <maml:name>zertoPort</maml:name>
         <maml:Description>
           <maml:para>Zerto Virtual Manager management port. Default value is 9669.</maml:para>
@@ -371,7 +371,7 @@
         </dev:type>
         <dev:defaultValue>"9669"</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="server, zvm">
         <maml:name>zertoServer</maml:name>
         <maml:Description>
           <maml:para>IP address or FQDN of your Zerto Management Server</maml:para>
@@ -554,7 +554,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vraId">
           <maml:name>vraIdentifier</maml:name>
           <maml:Description>
             <maml:para>Identifier of the VRA to be updated.</maml:para>
@@ -639,7 +639,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vraId">
         <maml:name>vraIdentifier</maml:name>
         <maml:Description>
           <maml:para>Identifier of the VRA to be updated.</maml:para>
@@ -967,7 +967,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="helpId">
           <maml:name>helpIdentifier</maml:name>
           <maml:Description>
             <maml:para>Returns alerts for the specified helpIdentifier</maml:para>
@@ -1003,7 +1003,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>Returns alerts for the specified siteIdentifier</maml:para>
@@ -1027,7 +1027,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vpgId">
           <maml:name>vpgIdentifier</maml:name>
           <maml:Description>
             <maml:para>Returns alerts for the specified vraIdentifier</maml:para>
@@ -1039,7 +1039,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="zorgId">
           <maml:name>zorgIdentifier</maml:name>
           <maml:Description>
             <maml:para>Returns alerts for the specified zorgIdentifier</maml:para>
@@ -1144,7 +1144,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="helpId">
         <maml:name>helpIdentifier</maml:name>
         <maml:Description>
           <maml:para>Returns alerts for the specified helpIdentifier</maml:para>
@@ -1204,7 +1204,7 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
         <maml:name>siteIdentifier</maml:name>
         <maml:Description>
           <maml:para>Returns alerts for the specified siteIdentifier</maml:para>
@@ -1228,7 +1228,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vpgId">
         <maml:name>vpgIdentifier</maml:name>
         <maml:Description>
           <maml:para>Returns alerts for the specified vraIdentifier</maml:para>
@@ -1240,7 +1240,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="zorgId">
         <maml:name>zorgIdentifier</maml:name>
         <maml:Description>
           <maml:para>Returns alerts for the specified zorgIdentifier</maml:para>
@@ -1348,7 +1348,7 @@
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Get-ZertoDatastore</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="datastoreId">
           <maml:name>datastoreIdentifier</maml:name>
           <maml:Description>
             <maml:para>datastoreIdentifier or array of datastoreIdentifiers to be queried</maml:para>
@@ -1363,7 +1363,7 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="datastoreId">
         <maml:name>datastoreIdentifier</maml:name>
         <maml:Description>
           <maml:para>datastoreIdentifier or array of datastoreIdentifiers to be queried</maml:para>
@@ -1444,7 +1444,7 @@
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Get-ZertoEvent</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="alertId">
           <maml:name>alertIdentifier</maml:name>
           <maml:Description>
             <maml:para>The internal alert identifier for the Event</maml:para>
@@ -1459,7 +1459,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>category</maml:name>
           <maml:Description>
-            <maml:para>The type of event to return. This filter behaves in the same way as the eventCategory filter. Possible Values are: Possible Values are: '0' or 'All', '1' or 'Events', '2' or 'Alerts'</maml:para>
+            <maml:para>The type of event to return. This filter behaves in the same way as the eventCategory filter. Possible Values are: Possible Values are: 'All', 'Events', 'Alerts'</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1483,7 +1483,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>entityType</maml:name>
           <maml:Description>
-            <maml:para>The type of entity for which you wish to return results. Possible Values are: '0' or 'VPG', '1' or 'VRA', '2' or 'Unknown', or '3' or 'Site'</maml:para>
+            <maml:para>The type of entity for which you wish to return results. Possible Values are: 'VPG', 'VRA', 'Unknown', or 'Site'</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1495,7 +1495,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>eventCategory</maml:name>
           <maml:Description>
-            <maml:para>This filter behaves in the same way as the category filter. If both category and eventCategory filters are specified, only the category filter value is used and the eventCategory filter value is ignored. The type of event to return. Possible Values are: '0' or 'All', '1' or 'Events', '2' or 'Alerts'</maml:para>
+            <maml:para>This filter behaves in the same way as the category filter. If both category and eventCategory filters are specified, only the category filter value is used and the eventCategory filter value is ignored. The type of event to return. Possible Values are: 'All', 'Events', 'Alerts'</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1516,7 +1516,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The internal site identifier for which you want to return events.</maml:para>
@@ -1564,7 +1564,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vpgName">
           <maml:name>vpg</maml:name>
           <maml:Description>
             <maml:para>The name of the VPG for which you want to return events.</maml:para>
@@ -1576,7 +1576,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vpgId">
           <maml:name>vpgIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG for which you want to return events.</maml:para>
@@ -1588,7 +1588,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="zorgId">
           <maml:name>zorgIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the ZORG, Zerto organization, defined in the Zerto Cloud Manager for which you want to return results.</maml:para>
@@ -1660,7 +1660,7 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="alertId">
         <maml:name>alertIdentifier</maml:name>
         <maml:Description>
           <maml:para>The internal alert identifier for the Event</maml:para>
@@ -1687,7 +1687,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>category</maml:name>
         <maml:Description>
-          <maml:para>The type of event to return. This filter behaves in the same way as the eventCategory filter. Possible Values are: Possible Values are: '0' or 'All', '1' or 'Events', '2' or 'Alerts'</maml:para>
+          <maml:para>The type of event to return. This filter behaves in the same way as the eventCategory filter. Possible Values are: Possible Values are: 'All', 'Events', 'Alerts'</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1723,7 +1723,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>entityType</maml:name>
         <maml:Description>
-          <maml:para>The type of entity for which you wish to return results. Possible Values are: '0' or 'VPG', '1' or 'VRA', '2' or 'Unknown', or '3' or 'Site'</maml:para>
+          <maml:para>The type of entity for which you wish to return results. Possible Values are: 'VPG', 'VRA', 'Unknown', or 'Site'</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1735,7 +1735,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>eventCategory</maml:name>
         <maml:Description>
-          <maml:para>This filter behaves in the same way as the category filter. If both category and eventCategory filters are specified, only the category filter value is used and the eventCategory filter value is ignored. The type of event to return. Possible Values are: '0' or 'All', '1' or 'Events', '2' or 'Alerts'</maml:para>
+          <maml:para>This filter behaves in the same way as the category filter. If both category and eventCategory filters are specified, only the category filter value is used and the eventCategory filter value is ignored. The type of event to return. Possible Values are: 'All', 'Events', 'Alerts'</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1768,7 +1768,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
         <maml:name>siteIdentifier</maml:name>
         <maml:Description>
           <maml:para>The internal site identifier for which you want to return events.</maml:para>
@@ -1828,7 +1828,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vpgName">
         <maml:name>vpg</maml:name>
         <maml:Description>
           <maml:para>The name of the VPG for which you want to return events.</maml:para>
@@ -1840,7 +1840,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vpgId">
         <maml:name>vpgIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the VPG for which you want to return events.</maml:para>
@@ -1852,7 +1852,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="zorgId">
         <maml:name>zorgIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the ZORG, Zerto organization, defined in the Zerto Cloud Manager for which you want to return results.</maml:para>
@@ -2166,7 +2166,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoPeerSite</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier(s) of the peer site(s) for which information is to be returned.</maml:para>
@@ -2253,7 +2253,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="siteId">
         <maml:name>siteIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier(s) of the peer site(s) for which information is to be returned.</maml:para>
@@ -2349,7 +2349,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>priority</maml:name>
           <maml:Description>
-            <maml:para>The priority specified for the VPG. Possible values are: '0' or 'Low', '1' or 'Medium', '2' or 'High'</maml:para>
+            <maml:para>The priority specified for the VPG. Possible values are: 'Low', 'Medium', or 'High'</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2358,7 +2358,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="protectedSiteId">
           <maml:name>protectedSiteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the protected site where the VPG virtual machines are protected.</maml:para>
@@ -2382,7 +2382,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="recoverySiteId">
           <maml:name>recoverySiteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the recovery site where the VPG virtual machines are recovered.</maml:para>
@@ -2457,7 +2457,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoProtectedVm</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="vmId">
           <maml:name>vmIdentifier</maml:name>
           <maml:Description>
             <maml:para>vmIdentifier(s) for which to return information</maml:para>
@@ -2487,7 +2487,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>priority</maml:name>
         <maml:Description>
-          <maml:para>The priority specified for the VPG. Possible values are: '0' or 'Low', '1' or 'Medium', '2' or 'High'</maml:para>
+          <maml:para>The priority specified for the VPG. Possible values are: 'Low', 'Medium', or 'High'</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2496,7 +2496,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="protectedSiteId">
         <maml:name>protectedSiteIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the protected site where the VPG virtual machines are protected.</maml:para>
@@ -2520,7 +2520,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="recoverySiteId">
         <maml:name>recoverySiteIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the recovery site where the VPG virtual machines are recovered.</maml:para>
@@ -2568,7 +2568,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="vmId">
         <maml:name>vmIdentifier</maml:name>
         <maml:Description>
           <maml:para>vmIdentifier(s) for which to return information</maml:para>
@@ -3437,7 +3437,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoServiceProfile</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the site for which service profiles should be returned.</maml:para>
@@ -3464,7 +3464,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
         <maml:name>siteIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the site for which service profiles should be returned.</maml:para>
@@ -3588,7 +3588,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>status</maml:name>
           <maml:Description>
-            <maml:para>The status of the task. Possible values are: '1' or 'InProgress', '3' or 'Paused', '4' or 'Failed', '6' or 'Completed', '7' or 'Cancelling'</maml:para>
+            <maml:para>The status of the task. Possible values are: 'InProgress', 'Paused', 'Failed', 'Completed', or 'Cancelling'</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3612,7 +3612,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoTask</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="taskId">
           <maml:name>taskIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier(s) for which task information is to be returned.</maml:para>
@@ -3692,7 +3692,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>status</maml:name>
         <maml:Description>
-          <maml:para>The status of the task. Possible values are: '1' or 'InProgress', '3' or 'Paused', '4' or 'Failed', '6' or 'Completed', '7' or 'Cancelling'</maml:para>
+          <maml:para>The status of the task. Possible values are: 'InProgress', 'Paused', 'Failed', 'Completed', or 'Cancelling'</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3701,7 +3701,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="taskId">
         <maml:name>taskIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier(s) for which task information is to be returned.</maml:para>
@@ -3879,7 +3879,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the Zerto Virtual Manager site.</maml:para>
@@ -3905,7 +3905,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the Zerto Virtual Manager site.</maml:para>
@@ -3931,7 +3931,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="hostId">
           <maml:name>hostIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the host at the selected site to return information for only one host.</maml:para>
@@ -3943,7 +3943,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the Zerto Virtual Manager site.</maml:para>
@@ -3969,7 +3969,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the Zerto Virtual Manager site.</maml:para>
@@ -3995,7 +3995,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the Zerto Virtual Manager site.</maml:para>
@@ -4010,7 +4010,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoVirtualizationSite</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="hostId">
           <maml:name>hostIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the host at the selected site to return information for only one host.</maml:para>
@@ -4033,7 +4033,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the Zerto Virtual Manager site.</maml:para>
@@ -4059,7 +4059,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the Zerto Virtual Manager site.</maml:para>
@@ -4085,7 +4085,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the Zerto Virtual Manager site.</maml:para>
@@ -4100,7 +4100,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoVirtualizationSite</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the Zerto Virtual Manager site.</maml:para>
@@ -4126,7 +4126,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoVirtualizationSite</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
           <maml:name>siteIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the Zerto Virtual Manager site.</maml:para>
@@ -4201,7 +4201,7 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="hostId">
         <maml:name>hostIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the host at the selected site to return information for only one host.</maml:para>
@@ -4249,7 +4249,7 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="siteId">
         <maml:name>siteIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the Zerto Virtual Manager site.</maml:para>
@@ -4334,7 +4334,7 @@
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Get-ZertoVolume</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="datastoreId, dsId">
           <maml:name>datastoreIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the datastore.</maml:para>
@@ -4346,7 +4346,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="owningVmId">
           <maml:name>owningVmIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the owning virtual machine.</maml:para>
@@ -4358,7 +4358,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="protectedVmId">
           <maml:name>protectedVmIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the protected virtual machine.</maml:para>
@@ -4382,7 +4382,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vpgId">
           <maml:name>vpgIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG.</maml:para>
@@ -4397,7 +4397,7 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="datastoreId, dsId">
         <maml:name>datastoreIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the datastore.</maml:para>
@@ -4409,7 +4409,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="owningVmId">
         <maml:name>owningVmIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the owning virtual machine.</maml:para>
@@ -4421,7 +4421,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="protectedVmId">
         <maml:name>protectedVmIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the protected virtual machine.</maml:para>
@@ -4445,7 +4445,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vpgId">
         <maml:name>vpgIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the VPG.</maml:para>
@@ -4570,7 +4570,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>priority</maml:name>
           <maml:Description>
-            <maml:para>The VPG priority. Possible values are: '0' or 'Low', '1' or 'Medium', '2' or 'High'</maml:para>
+            <maml:para>The VPG priority. Possible values are: 'Low', 'Medium', 'High'</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -4701,7 +4701,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vpgId, protectionGroupId, pgId">
           <maml:name>protectionGroupIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier(s) of the Virtual Protection Group to return</maml:para>
@@ -4739,7 +4739,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vpgId, protectionGroupId, pgId">
           <maml:name>protectionGroupIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier(s) of the Virtual Protection Group to return</maml:para>
@@ -4810,7 +4810,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoVpg</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vpgId, protectionGroupId, pgId">
           <maml:name>protectionGroupIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier(s) of the Virtual Protection Group to return</maml:para>
@@ -4990,7 +4990,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>priority</maml:name>
         <maml:Description>
-          <maml:para>The VPG priority. Possible values are: '0' or 'Low', '1' or 'Medium', '2' or 'High'</maml:para>
+          <maml:para>The VPG priority. Possible values are: 'Low', 'Medium', 'High'</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -5023,7 +5023,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vpgId, protectionGroupId, pgId">
         <maml:name>protectionGroupIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier(s) of the Virtual Protection Group to return</maml:para>
@@ -5235,7 +5235,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5261,7 +5261,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5287,7 +5287,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5313,7 +5313,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5339,7 +5339,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5365,7 +5365,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5380,7 +5380,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoVpgSetting</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="nicId">
           <maml:name>nicIdentifier</maml:name>
           <maml:Description>
             <maml:para>Return NIC information for specified NIC of the specified VM</maml:para>
@@ -5392,7 +5392,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vmId">
           <maml:name>vmIdentifier</maml:name>
           <maml:Description>
             <maml:para>VM Identifier</maml:para>
@@ -5404,7 +5404,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5430,7 +5430,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vmId">
           <maml:name>vmIdentifier</maml:name>
           <maml:Description>
             <maml:para>VM Identifier</maml:para>
@@ -5442,7 +5442,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5468,7 +5468,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5494,7 +5494,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5520,7 +5520,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5546,7 +5546,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5572,7 +5572,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5587,7 +5587,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoVpgSetting</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vmId">
           <maml:name>vmIdentifier</maml:name>
           <maml:Description>
             <maml:para>VM Identifier</maml:para>
@@ -5599,7 +5599,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="volumeId">
           <maml:name>volumeIdentifier</maml:name>
           <maml:Description>
             <maml:para>Return volume information for the specified volume of the specified VM</maml:para>
@@ -5611,7 +5611,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5626,7 +5626,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoVpgSetting</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vmId">
           <maml:name>vmIdentifier</maml:name>
           <maml:Description>
             <maml:para>VM Identifier</maml:para>
@@ -5649,7 +5649,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5664,7 +5664,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoVpgSetting</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vmId">
           <maml:name>vmIdentifier</maml:name>
           <maml:Description>
             <maml:para>VM Identifier</maml:para>
@@ -5676,7 +5676,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5702,7 +5702,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5717,7 +5717,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoVpgSetting</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -5804,7 +5804,7 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="nicId">
         <maml:name>nicIdentifier</maml:name>
         <maml:Description>
           <maml:para>Return NIC information for specified NIC of the specified VM</maml:para>
@@ -5888,7 +5888,7 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vmId">
         <maml:name>vmIdentifier</maml:name>
         <maml:Description>
           <maml:para>VM Identifier</maml:para>
@@ -5912,7 +5912,7 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="volumeId">
         <maml:name>volumeIdentifier</maml:name>
         <maml:Description>
           <maml:para>Return volume information for the specified volume of the specified VM</maml:para>
@@ -5936,7 +5936,7 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="vpgSettingsId, settingsId">
         <maml:name>vpgSettingsIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the VPG settings object for which information is retrieved.</maml:para>
@@ -6176,7 +6176,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-ZertoVra</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vraId">
           <maml:name>vraIdentifier</maml:name>
           <maml:Description>
             <maml:para>Returns information for provided VRA identifier(s)</maml:para>
@@ -6299,7 +6299,7 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="vraId">
         <maml:name>vraIdentifier</maml:name>
         <maml:Description>
           <maml:para>Returns information for provided VRA identifier(s)</maml:para>
@@ -6403,7 +6403,7 @@
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Get-ZertoZorg</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="zorgId">
           <maml:name>zorgIdentifier</maml:name>
           <maml:Description>
             <maml:para>Identifier(s) of the ZORG.</maml:para>
@@ -6418,7 +6418,7 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="zorgId">
         <maml:name>zorgIdentifier</maml:name>
         <maml:Description>
           <maml:para>Identifier(s) of the ZORG.</maml:para>
@@ -6498,7 +6498,7 @@
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Get-ZertoZsspSession</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="zsspSessionId">
           <maml:name>zsspSessionIdentifier</maml:name>
           <maml:Description>
             <maml:para>ZSSP Session Id(s) to get information.</maml:para>
@@ -6513,7 +6513,7 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="zsspSessionId">
         <maml:name>zsspSessionIdentifier</maml:name>
         <maml:Description>
           <maml:para>ZSSP Session Id(s) to get information.</maml:para>
@@ -7103,7 +7103,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="checkpointId">
           <maml:name>checkpointIdentifier</maml:name>
           <maml:Description>
             <maml:para>Checkpoint Identifier to use as the Point-In-Time to rollback to.</maml:para>
@@ -7118,9 +7118,9 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
           <maml:name>commitPolicy</maml:name>
           <maml:Description>
-            <maml:para>0: After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.</maml:para>
-            <maml:para>1: After the seconds specified in the commitValue setting have elapsed, the failover continues, committing the virtual machines in the recovery site.</maml:para>
-            <maml:para>2: The virtual machines in the VPG being failed over remain in the Before Commit state until either they are committed with Commit a failover, or rolled back with Roll back a failover.</maml:para>
+            <maml:para>'Rollback': After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.</maml:para>
+            <maml:para>'Commit': After the seconds specified in the commitValue setting have elapsed, the failover continues, committing the virtual machines in the recovery site.</maml:para>
+            <maml:para>'None': The virtual machines in the VPG being failed over remain in the Before Commit state until either they are committed with Commit a failover, or rolled back with Roll back a failover.</maml:para>
             <maml:para>Default is the Site Settings setting.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
@@ -7184,7 +7184,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="7" aliases="none">
           <maml:name>vmName</maml:name>
           <maml:Description>
-            <maml:para>Name(s) of VMs in the</maml:para>
+            <maml:para>Name(s) of VMs in the VPG to failover</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -7196,7 +7196,7 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="checkpointId">
         <maml:name>checkpointIdentifier</maml:name>
         <maml:Description>
           <maml:para>Checkpoint Identifier to use as the Point-In-Time to rollback to.</maml:para>
@@ -7211,9 +7211,9 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
         <maml:name>commitPolicy</maml:name>
         <maml:Description>
-          <maml:para>0: After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.</maml:para>
-          <maml:para>1: After the seconds specified in the commitValue setting have elapsed, the failover continues, committing the virtual machines in the recovery site.</maml:para>
-          <maml:para>2: The virtual machines in the VPG being failed over remain in the Before Commit state until either they are committed with Commit a failover, or rolled back with Roll back a failover.</maml:para>
+          <maml:para>'Rollback': After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.</maml:para>
+          <maml:para>'Commit': After the seconds specified in the commitValue setting have elapsed, the failover continues, committing the virtual machines in the recovery site.</maml:para>
+          <maml:para>'None': The virtual machines in the VPG being failed over remain in the Before Commit state until either they are committed with Commit a failover, or rolled back with Roll back a failover.</maml:para>
           <maml:para>Default is the Site Settings setting.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
@@ -7277,7 +7277,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="7" aliases="none">
         <maml:name>vmName</maml:name>
         <maml:Description>
-          <maml:para>Name(s) of VMs in the</maml:para>
+          <maml:para>Name(s) of VMs in the VPG to failover</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
         <dev:type>
@@ -7668,7 +7668,10 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
           <maml:name>commitPolicy</maml:name>
           <maml:Description>
-            <maml:para>The policy to use after the move enters a 'Before Commit' state. If omitted, the site settings default will be applied. Valid values are: '0' or 'Rollback', '1' or 'Commit', '2' or 'None'. Please see Zerto API Documentation for additional information.</maml:para>
+            <maml:para>'Rollback': After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.</maml:para>
+            <maml:para>'Commit': After the seconds specified in the commitValue setting have elapsed, the failover continues, committing the virtual machines in the recovery site.</maml:para>
+            <maml:para>'None': The virtual machines in the VPG being failed over remain in the Before Commit state until either they are committed with Commit a failover, or rolled back with Roll back a failover.</maml:para>
+            <maml:para>Default is the Site Settings setting.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -7752,7 +7755,10 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
         <maml:name>commitPolicy</maml:name>
         <maml:Description>
-          <maml:para>The policy to use after the move enters a 'Before Commit' state. If omitted, the site settings default will be applied. Valid values are: '0' or 'Rollback', '1' or 'Commit', '2' or 'None'. Please see Zerto API Documentation for additional information.</maml:para>
+          <maml:para>'Rollback': After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.</maml:para>
+          <maml:para>'Commit': After the seconds specified in the commitValue setting have elapsed, the failover continues, committing the virtual machines in the recovery site.</maml:para>
+          <maml:para>'None': The virtual machines in the VPG being failed over remain in the Before Commit state until either they are committed with Commit a failover, or rolled back with Roll back a failover.</maml:para>
+          <maml:para>Default is the Site Settings setting.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -9923,7 +9929,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-ZertoVpgSettingsIdentifier</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="vpgId">
           <maml:name>vpgIdentifier</maml:name>
           <maml:Description>
             <maml:para>Identifier of the VPG to create a VPG settings identifier. If a vpgIdentifier is not provided, a new VPG settings object is created without any configured settings. This would be used for creating a new VPG from scratch.</maml:para>
@@ -9950,7 +9956,7 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="vpgId">
         <maml:name>vpgIdentifier</maml:name>
         <maml:Description>
           <maml:para>Identifier of the VPG to create a VPG settings identifier. If a vpgIdentifier is not provided, a new VPG settings object is created without any configured settings. This would be used for creating a new VPG from scratch.</maml:para>
@@ -10052,7 +10058,7 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="vpgId">
           <maml:name>vpgidentifier</maml:name>
           <maml:Description>
             <maml:para>vpgIdentifier(s) of the VPG(s) to delete.</maml:para>
@@ -10172,7 +10178,7 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="vpgId">
         <maml:name>vpgidentifier</maml:name>
         <maml:Description>
           <maml:para>vpgIdentifier(s) of the VPG(s) to delete.</maml:para>
@@ -10390,7 +10396,7 @@
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Save-ZertoVpgSettings</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="vpgSettingsId">
           <maml:name>vpgSettingsIdentifier</maml:name>
           <maml:Description>
             <maml:para>VpgSettings Identifier to save</maml:para>
@@ -10427,7 +10433,7 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="vpgSettingsId">
         <maml:name>vpgSettingsIdentifier</maml:name>
         <maml:Description>
           <maml:para>VpgSettings Identifier to save</maml:para>
@@ -10524,7 +10530,7 @@
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Set-ZertoAlert</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="identifier">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="alertIdentifier, identifier">
           <maml:name>alertId</maml:name>
           <maml:Description>
             <maml:para>Alert identifier(s) to be dismissed or undismissed.</maml:para>
@@ -10572,7 +10578,7 @@
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Set-ZertoAlert</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="identifier">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="alertIdentifier, identifier">
           <maml:name>alertId</maml:name>
           <maml:Description>
             <maml:para>Alert identifier(s) to be dismissed or undismissed.</maml:para>
@@ -10620,7 +10626,7 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="identifier">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="alertIdentifier, identifier">
         <maml:name>alertId</maml:name>
         <maml:Description>
           <maml:para>Alert identifier(s) to be dismissed or undismissed.</maml:para>
@@ -10894,7 +10900,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="checkpointId">
           <maml:name>checkpointIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the checkpoint to use for cloning. If unspecified, the latest checkpoint will be used.</maml:para>
@@ -10933,7 +10939,7 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="checkpointId">
         <maml:name>checkpointIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the checkpoint to use for cloning. If unspecified, the latest checkpoint will be used.</maml:para>
@@ -11054,7 +11060,7 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="checkpointId">
           <maml:name>checkpointIdentifier</maml:name>
           <maml:Description>
             <maml:para>The identifier of the checkpoint to use for testing. If unspecified, the latest checkpoint will be used.</maml:para>
@@ -11081,7 +11087,7 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="checkpointId">
         <maml:name>checkpointIdentifier</maml:name>
         <maml:Description>
           <maml:para>The identifier of the checkpoint to use for testing. If unspecified, the latest checkpoint will be used.</maml:para>

--- a/docs/Connect-ZertoServer.md
+++ b/docs/Connect-ZertoServer.md
@@ -68,7 +68,7 @@ Default value is 9669.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: port
 
 Required: False
 Position: 1
@@ -83,7 +83,7 @@ IP address or FQDN of your Zerto Management Server
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: server, zvm
 
 Required: True
 Position: 0

--- a/docs/Edit-ZertoVra.md
+++ b/docs/Edit-ZertoVra.md
@@ -110,7 +110,7 @@ Identifier of the VRA to be updated.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: vraId
 
 Required: True
 Position: Named

--- a/docs/Get-ZertoAlert.md
+++ b/docs/Get-ZertoAlert.md
@@ -164,7 +164,7 @@ Returns alerts for the specified helpIdentifier
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: helpId
 
 Required: False
 Position: Named
@@ -239,7 +239,7 @@ Returns alerts for the specified siteIdentifier
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: siteId
 
 Required: False
 Position: Named
@@ -270,7 +270,7 @@ Returns alerts for the specified vraIdentifier
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: vpgId
 
 Required: False
 Position: Named
@@ -285,7 +285,7 @@ Returns alerts for the specified zorgIdentifier
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: zorgId
 
 Required: False
 Position: Named

--- a/docs/Get-ZertoDatastore.md
+++ b/docs/Get-ZertoDatastore.md
@@ -49,7 +49,7 @@ datastoreIdentifier or array of datastoreIdentifiers to be queried
 ```yaml
 Type: String[]
 Parameter Sets: datastoreIdentifier
-Aliases:
+Aliases: datastoreId
 
 Required: False
 Position: Named

--- a/docs/Get-ZertoEvent.md
+++ b/docs/Get-ZertoEvent.md
@@ -81,7 +81,7 @@ The internal alert identifier for the Event
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: alertId
 
 Required: False
 Position: Named
@@ -106,9 +106,7 @@ Accept wildcard characters: False
 ```
 
 ### -category
-The type of event to return.
-This filter behaves in the same way as the eventCategory filter.
-Possible Values are: Possible Values are: '0' or 'All', '1' or 'Events', '2' or 'Alerts'
+The type of event to return. This filter behaves in the same way as the eventCategory filter. Possible Values are: Possible Values are: 'All', 'Events', 'Alerts'
 
 ```yaml
 Type: String
@@ -155,8 +153,7 @@ Accept wildcard characters: False
 ```
 
 ### -entityType
-The type of entity for which you wish to return results.
-Possible Values are: '0' or 'VPG', '1' or 'VRA', '2' or 'Unknown', or '3' or 'Site'
+The type of entity for which you wish to return results. Possible Values are: 'VPG', 'VRA', 'Unknown', or 'Site'
 
 ```yaml
 Type: String
@@ -171,10 +168,7 @@ Accept wildcard characters: False
 ```
 
 ### -eventCategory
-This filter behaves in the same way as the category filter.
-If both category and eventCategory filters are specified, only the category filter value is used and the eventCategory filter value is ignored.
-The type of event to return.
-Possible Values are: '0' or 'All', '1' or 'Events', '2' or 'Alerts'
+This filter behaves in the same way as the category filter. If both category and eventCategory filters are specified, only the category filter value is used and the eventCategory filter value is ignored. The type of event to return. Possible Values are: 'All', 'Events', 'Alerts'
 
 ```yaml
 Type: String
@@ -226,7 +220,7 @@ The internal site identifier for which you want to return events.
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: siteId
 
 Required: False
 Position: Named
@@ -304,7 +298,7 @@ The name of the VPG for which you want to return events.
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: vpgName
 
 Required: False
 Position: Named
@@ -319,7 +313,7 @@ The identifier of the VPG for which you want to return events.
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: vpgId
 
 Required: False
 Position: Named
@@ -334,7 +328,7 @@ The identifier of the ZORG, Zerto organization, defined in the Zerto Cloud Manag
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: zorgId
 
 Required: False
 Position: Named

--- a/docs/Get-ZertoPeerSite.md
+++ b/docs/Get-ZertoPeerSite.md
@@ -152,7 +152,7 @@ The identifier(s) of the peer site(s) for which information is to be returned.
 ```yaml
 Type: String[]
 Parameter Sets: siteIdentifier
-Aliases:
+Aliases: siteId
 
 Required: True
 Position: Named

--- a/docs/Get-ZertoProtectedVm.md
+++ b/docs/Get-ZertoProtectedVm.md
@@ -82,8 +82,7 @@ Accept wildcard characters: False
 ```
 
 ### -priority
-The priority specified for the VPG.
-Possible values are: '0' or 'Low', '1' or 'Medium', '2' or 'High'
+The priority specified for the VPG. Possible values are: 'Low', 'Medium', or 'High'
 
 ```yaml
 Type: String
@@ -103,7 +102,7 @@ The identifier of the protected site where the VPG virtual machines are protecte
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: protectedSiteId
 
 Required: False
 Position: Named
@@ -134,7 +133,7 @@ The identifier of the recovery site where the VPG virtual machines are recovered
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: recoverySiteId
 
 Required: False
 Position: Named
@@ -198,7 +197,7 @@ vmIdentifier(s) for which to return information
 ```yaml
 Type: String[]
 Parameter Sets: vmIdentifier
-Aliases:
+Aliases: vmId
 
 Required: True
 Position: Named

--- a/docs/Get-ZertoServiceProfile.md
+++ b/docs/Get-ZertoServiceProfile.md
@@ -62,7 +62,7 @@ The identifier of the site for which service profiles should be returned.
 ```yaml
 Type: String
 Parameter Sets: siteIdentifier
-Aliases:
+Aliases: siteId
 
 Required: False
 Position: Named

--- a/docs/Get-ZertoTask.md
+++ b/docs/Get-ZertoTask.md
@@ -123,8 +123,7 @@ Accept wildcard characters: False
 ```
 
 ### -status
-The status of the task.
-Possible values are: '1' or 'InProgress', '3' or 'Paused', '4' or 'Failed', '6' or 'Completed', '7' or 'Cancelling'
+The status of the task. Possible values are: 'InProgress', 'Paused', 'Failed', 'Completed', or 'Cancelling'
 
 ```yaml
 Type: String
@@ -144,7 +143,7 @@ The identifier(s) for which task information is to be returned.
 ```yaml
 Type: String[]
 Parameter Sets: taskIdentifier
-Aliases:
+Aliases: taskId
 
 Required: False
 Position: Named

--- a/docs/Get-ZertoVirtualizationSite.md
+++ b/docs/Get-ZertoVirtualizationSite.md
@@ -162,7 +162,7 @@ The identifier of the host at the selected site to return information for only o
 ```yaml
 Type: String
 Parameter Sets: devices, hosts
-Aliases:
+Aliases: hostId
 
 Required: False
 Position: Named
@@ -223,7 +223,7 @@ The identifier of the Zerto Virtual Manager site.
 ```yaml
 Type: String
 Parameter Sets: folders, devices, vms, resourcePools, networks, hosts, hostClusters, datastores, datastoreClusters, siteIdentifier
-Aliases:
+Aliases: siteId
 
 Required: True
 Position: Named

--- a/docs/Get-ZertoVolume.md
+++ b/docs/Get-ZertoVolume.md
@@ -57,7 +57,7 @@ The identifier of the datastore.
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: datastoreId, dsId
 
 Required: False
 Position: Named
@@ -72,7 +72,7 @@ The identifier of the owning virtual machine.
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: owningVmId
 
 Required: False
 Position: Named
@@ -87,7 +87,7 @@ The identifier of the protected virtual machine.
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: protectedVmId
 
 Required: False
 Position: Named
@@ -118,7 +118,7 @@ The identifier of the VPG.
 ```yaml
 Type: String
 Parameter Sets: filter
-Aliases:
+Aliases: vpgId
 
 Required: False
 Position: Named

--- a/docs/Get-ZertoVpg.md
+++ b/docs/Get-ZertoVpg.md
@@ -265,8 +265,7 @@ Accept wildcard characters: False
 
 ### -priority
 
-The VPG priority.
-Possible values are: '0' or 'Low', '1' or 'Medium', '2' or 'High'
+The VPG priority. Possible values are: 'Low', 'Medium', 'High'
 
 ```yaml
 Type: String
@@ -321,7 +320,7 @@ The identifier(s) of the Virtual Protection Group to return
 ```yaml
 Type: String[]
 Parameter Sets: stats, checkpoints, protectionGroupIdentifier
-Aliases:
+Aliases: vpgId, protectionGroupId, pgId
 
 Required: True
 Position: Named

--- a/docs/Get-ZertoVpgSetting.md
+++ b/docs/Get-ZertoVpgSetting.md
@@ -249,7 +249,7 @@ Return NIC information for specified NIC of the specified VM
 ```yaml
 Type: String
 Parameter Sets: nicIdentifier
-Aliases:
+Aliases: nicId
 
 Required: True
 Position: Named
@@ -354,7 +354,7 @@ VM Identifier
 ```yaml
 Type: String
 Parameter Sets: volumeIdentifier, volumes, nicIdentifier, nics, vmIdentifier
-Aliases:
+Aliases: vmId
 
 Required: True
 Position: Named
@@ -384,7 +384,7 @@ Return volume information for the specified volume of the specified VM
 ```yaml
 Type: String
 Parameter Sets: volumeIdentifier
-Aliases:
+Aliases: volumeId
 
 Required: True
 Position: Named
@@ -414,7 +414,7 @@ The identifier of the VPG settings object for which information is retrieved.
 ```yaml
 Type: String
 Parameter Sets: volumeIdentifier, volumes, nicIdentifier, nics, vmIdentifier, vms, scripting, recovery, priority, networks, journal, bootGroup
-Aliases:
+Aliases: vpgSettingsId, settingsId
 
 Required: True
 Position: Named
@@ -426,7 +426,7 @@ Accept wildcard characters: False
 ```yaml
 Type: String
 Parameter Sets: basic, schedulerPeriod, retentionPeriod, dayOfWeek, backup, vpgSettingsIdentifier
-Aliases:
+Aliases: vpgSettingsId, settingsId
 
 Required: True
 Position: Named

--- a/docs/Get-ZertoVra.md
+++ b/docs/Get-ZertoVra.md
@@ -201,7 +201,7 @@ Returns information for provided VRA identifier(s)
 ```yaml
 Type: String[]
 Parameter Sets: vraIdentifier
-Aliases:
+Aliases: vraId
 
 Required: False
 Position: Named

--- a/docs/Get-ZertoZorg.md
+++ b/docs/Get-ZertoZorg.md
@@ -49,7 +49,7 @@ Identifier(s) of the ZORG.
 ```yaml
 Type: String[]
 Parameter Sets: zorgIdentifier
-Aliases:
+Aliases: zorgId
 
 Required: False
 Position: Named

--- a/docs/Get-ZertoZsspSession.md
+++ b/docs/Get-ZertoZsspSession.md
@@ -42,7 +42,7 @@ ZSSP Session Id(s) to get information.
 ```yaml
 Type: String[]
 Parameter Sets: zsspSessionIdentifier
-Aliases:
+Aliases: zsspSessionId
 
 Required: False
 Position: Named

--- a/docs/Invoke-ZertoFailover.md
+++ b/docs/Invoke-ZertoFailover.md
@@ -38,7 +38,7 @@ Checkpoint Identifier to use as the Point-In-Time to rollback to.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: checkpointId
 
 Required: False
 Position: 1
@@ -48,11 +48,11 @@ Accept wildcard characters: False
 ```
 
 ### -commitPolicy
-0: After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.
+'Rollback': After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.
 
-1: After the seconds specified in the commitValue setting have elapsed, the failover continues, committing the virtual machines in the recovery site.
+'Commit': After the seconds specified in the commitValue setting have elapsed, the failover continues, committing the virtual machines in the recovery site.
 
-2: The virtual machines in the VPG being failed over remain in the Before Commit state until either they are committed with Commit a failover, or rolled back with Roll back a failover.
+'None': The virtual machines in the VPG being failed over remain in the Before Commit state until either they are committed with Commit a failover, or rolled back with Roll back a failover.
 
 Default is the Site Settings setting.
 
@@ -143,7 +143,7 @@ Accept wildcard characters: False
 ```
 
 ### -vmName
-Name(s) of VMs in the
+Name(s) of VMs in the VPG to failover
 
 ```yaml
 Type: String[]

--- a/docs/Invoke-ZertoMove.md
+++ b/docs/Invoke-ZertoMove.md
@@ -33,10 +33,13 @@ Starts a move operation of VPG "MyVpg"
 ## PARAMETERS
 
 ### -commitPolicy
-The policy to use after the move enters a 'Before Commit' state.
-If omitted, the site settings default will be applied.
-Valid values are: '0' or 'Rollback', '1' or 'Commit', '2' or 'None'.
-Please see Zerto API Documentation for additional information.
+'Rollback': After the seconds specified in the commitValue setting have elapsed, the failover is rolled back.
+
+'Commit': After the seconds specified in the commitValue setting have elapsed, the failover continues, committing the virtual machines in the recovery site.
+
+'None': The virtual machines in the VPG being failed over remain in the Before Commit state until either they are committed with Commit a failover, or rolled back with Roll back a failover.
+
+Default is the Site Settings setting.
 
 ```yaml
 Type: String

--- a/docs/New-ZertoVpgSettingsIdentifier.md
+++ b/docs/New-ZertoVpgSettingsIdentifier.md
@@ -66,7 +66,7 @@ This would be used for creating a new VPG from scratch.
 ```yaml
 Type: String
 Parameter Sets: existingVpg
-Aliases:
+Aliases: vpgId
 
 Required: True
 Position: Named

--- a/docs/Remove-ZertoVpg.md
+++ b/docs/Remove-ZertoVpg.md
@@ -103,7 +103,7 @@ vpgIdentifier(s) of the VPG(s) to delete.
 ```yaml
 Type: String[]
 Parameter Sets: vpgIdentifier
-Aliases:
+Aliases: vpgId
 
 Required: True
 Position: Named

--- a/docs/Save-ZertoVpgSettings.md
+++ b/docs/Save-ZertoVpgSettings.md
@@ -36,7 +36,7 @@ VpgSettings Identifier to save
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: vpgSettingsId
 
 Required: True
 Position: 0

--- a/docs/Set-ZertoAlert.md
+++ b/docs/Set-ZertoAlert.md
@@ -49,7 +49,7 @@ Alert identifier(s) to be dismissed or undismissed.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: identifier
+Aliases: alertIdentifier, identifier
 
 Required: True
 Position: Named

--- a/docs/Start-ZertoCloneVpg.md
+++ b/docs/Start-ZertoCloneVpg.md
@@ -38,7 +38,7 @@ If unspecified, the latest checkpoint will be used.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: checkpointId
 
 Required: False
 Position: 1

--- a/docs/Start-ZertoFailoverTest.md
+++ b/docs/Start-ZertoFailoverTest.md
@@ -38,7 +38,7 @@ If unspecified, the latest checkpoint will be used.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: checkpointId
 
 Required: False
 Position: 1


### PR DESCRIPTION
Fixes #11 

Adds ValidateSet() functionality where limited input operations are in use. Should migrate this later to Enums.

Also updates some parameters with Alias names. Help files updated to reflect changes.